### PR TITLE
allowEmptyValue support on swaggerize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0 (25/02/2016)
+
+- Add support for `allowEmptyValue` property in query and formData
+
 ### 1.0.0 (renamed to swaggerize-routes)
 
 - Alternately specify `x-handler` properties to reference handlers at either the operation or path level.

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -76,7 +76,8 @@ module.exports = function validator(options) {
                 schema: parameter.schema,
                 items: parameter.items,
                 properties: parameter.properties,
-                pattern: parameter.pattern
+                pattern: parameter.pattern,
+                allowEmptyValue: parameter.allowEmptyValue
             };
 
             if ((parameter.in === 'body' || parameter.in === 'formData') && template.schema) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -77,8 +77,12 @@ module.exports = function validator(options) {
                 items: parameter.items,
                 properties: parameter.properties,
                 pattern: parameter.pattern,
-                allowEmptyValue: parameter.allowEmptyValue
+                minLength: parameter.minLength
             };
+
+            if(parameter.allowEmptyValue === true) {
+              template.minLength = 0;
+            }
 
             if ((parameter.in === 'body' || parameter.in === 'formData') && template.schema) {
                 schema = enjoi(template.schema, {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -76,12 +76,11 @@ module.exports = function validator(options) {
                 schema: parameter.schema,
                 items: parameter.items,
                 properties: parameter.properties,
-                pattern: parameter.pattern,
-                minLength: parameter.minLength
+                pattern: parameter.pattern
             };
 
-            if(parameter.allowEmptyValue === true) {
-              template.minLength = 0;
+            if((parameter.in === 'query' || parameter.in === 'formData') && parameter.allowEmptyValue === true) {
+                template.minLength = 0;
             }
 
             if ((parameter.in === 'body' || parameter.in === 'formData') && template.schema) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swaggerize-routes",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Trevor Livingston <trlivingston@paypal.com>",
   "description": "Swagger based route building.",
   "main": "./lib/index",
@@ -16,7 +16,7 @@
     "caller": "^0.0.1",
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",
-    "enjoi": "git+https://github.com/worldline/enjoi.git#worldlineMaster",
+    "enjoi": "git+https://github.com/qtomasicchio/enjoi.git#worldlineMaster",
     "swagger-schema-official": "^2.0.0-"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swaggerize-routes",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "author": "Trevor Livingston <trlivingston@paypal.com>",
   "description": "Swagger based route building.",
   "main": "./lib/index",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "caller": "^0.0.1",
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",
-    "enjoi": "git+https://github.com/qtomasicchio/enjoi.git#worldlineMaster",
+    "enjoi": "git+https://github.com/worldline/enjoi.git#worldlineMaster",
     "swagger-schema-official": "^2.0.0-"
   },
   "devDependencies": {

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -252,58 +252,6 @@ test('validation', function (t) {
         });
     });
 
-    t.test('input fail (empty string)', function (t) {
-        t.plan(3);
-
-        validator.make({
-            name: 'id',
-            required: true,
-            type: 'string'
-        }).validate('', function (error) {
-            t.ok(error, 'error.');
-        });
-
-        validator.make({
-            name: 'id',
-            required: true,
-            type: 'string',
-            allowEmptyValue: false
-        }).validate('', function (error) {
-            t.ok(error, 'error.');
-        });
-
-        validator.make({
-            name: 'id',
-            required: true,
-            type: 'string',
-            minLength: 1
-        }).validate('', function (error) {
-            t.ok(error, 'error.');
-        });
-    });
-
-    t.test('input pass (empty string with allowEmtpyValue: true or minLength: 0)', function (t) {
-        t.plan(2);
-
-        validator.make({
-            name: 'id',
-            required: true,
-            type: 'string',
-            allowEmptyValue: true
-        }).validate('', function (error) {
-            t.ok(!error, 'no error.');
-        });
-
-        validator.make({
-            name: 'id',
-            required: true,
-            type: 'string',
-            minLength: 0
-        }).validate('', function (error) {
-            t.ok(!error, 'no error.');
-        });
-    });
-
     t.test('input ignore extra value', function(t) {
         t.plan(2);
 
@@ -317,6 +265,41 @@ test('validation', function (t) {
         v.validate({ id: 1, name: 'fluffy', extra: 'foo'}, function(error, result) {
             t.ok(!error, 'no error.');
             t.ok(!result.extra, 'No extra properties')
+        });
+    });
+
+    t.test('query empty param', function (t) {
+        t.plan(5);
+
+        validator.make({
+            name: 'foo',
+            required: true,
+            type: 'string',
+            in: 'query'
+        }).validate('', function (error) {
+            t.ok(error, 'error.');
+        });
+
+        [false, 'anything', 1].forEach(function(value) {
+            validator.make({
+                name: 'foo',
+                required: true,
+                type: 'string',
+                in: 'query',
+                allowEmptyValue: value
+            }).validate('', function (error) {
+                t.ok(error, 'error.');
+            });
+        });
+
+        validator.make({
+            name: 'foo',
+            required: true,
+            type: 'string',
+            in: 'query',
+            allowEmptyValue: true
+        }).validate('', function (error) {
+            t.ok(!error, 'no error.');
         });
     });
 
@@ -342,8 +325,38 @@ test('validation', function (t) {
         });
     });
 
-});
+    t.test('formData empty param', function (t) {
+        t.plan(5);
 
+        validator.make({
+            name: 'foo',
+            type: 'string',
+            in: 'formData'
+        }).validate('', function (error) {
+            t.ok(error, 'error.');
+        });
+
+        [false, 'anything', 1].forEach(function(value) {
+            validator.make({
+                name: 'foo',
+                type: 'string',
+                in: 'formData',
+                allowEmptyValue: value
+            }).validate('', function (error) {
+                t.ok(error, 'error.');
+            });
+        });
+
+        validator.make({
+            name: 'foo',
+            type: 'string',
+            in: 'formData',
+            allowEmptyValue: true
+        }).validate('', function (error) {
+            t.ok(!error, 'error.');
+        });
+    });
+});
 
 test('named validation', function (t) {
 

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -51,43 +51,6 @@ test('validation', function (t) {
         });
     });
 
-    t.test(' empty query param pass with allowEmptyValue: true', function (t) {
-        t.plan(3);
-
-        var functionnalValidatorAllowEmpty = validator.make({
-            name: 'emptyQs',
-            required: false,
-            type: 'string',
-            allowEmptyValue: true
-        });
-
-        functionnalValidatorAllowEmpty.validate('', function (error) {
-            t.ok(!error, 'no error.');
-        });
-
-
-        var functionnalValidatorMi = validator.make({
-            name: 'emptyQs',
-            required: false,
-            type: 'string',
-            minLength: 0
-        });
-
-        functionnalValidatorMi.validate('', function (error) {
-            t.ok(!error, 'no error.');
-        });
-
-        var functionnalValidator = validator.make({
-            name: 'emptyQs',
-            required: false,
-            type: 'string'
-        });
-
-        functionnalValidator.validate('', function (error) {
-            t.ok(error, 'error.');
-        });
-    });
-
     t.test('$ref default resolves to root schema', function (t) {
         t.plan(1);
 
@@ -289,6 +252,58 @@ test('validation', function (t) {
         });
     });
 
+    t.test('input fail (empty string)', function (t) {
+        t.plan(3);
+
+        validator.make({
+            name: 'id',
+            required: true,
+            type: 'string'
+        }).validate('', function (error) {
+            t.ok(error, 'error.');
+        });
+
+        validator.make({
+            name: 'id',
+            required: true,
+            type: 'string',
+            allowEmptyValue: false
+        }).validate('', function (error) {
+            t.ok(error, 'error.');
+        });
+
+        validator.make({
+            name: 'id',
+            required: true,
+            type: 'string',
+            minLength: 1
+        }).validate('', function (error) {
+            t.ok(error, 'error.');
+        });
+    });
+
+    t.test('input pass (empty string with allowEmtpyValue: true or minLength: 0)', function (t) {
+        t.plan(2);
+
+        validator.make({
+            name: 'id',
+            required: true,
+            type: 'string',
+            allowEmptyValue: true
+        }).validate('', function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        validator.make({
+            name: 'id',
+            required: true,
+            type: 'string',
+            minLength: 0
+        }).validate('', function (error) {
+            t.ok(!error, 'no error.');
+        });
+    });
+
     t.test('input ignore extra value', function(t) {
         t.plan(2);
 
@@ -405,5 +420,4 @@ test('named validation', function (t) {
       });
     });
   });
-
 });

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -51,6 +51,31 @@ test('validation', function (t) {
         });
     });
 
+    t.test(' empty query param pass with allowEmptyValue: true', function (t) {
+        t.plan(2);
+
+        var functionnalValidatorAllowEmpty = validator.make({
+            name: 'emptyQs',
+            required: false,
+            type: 'string',
+            allowEmptyValue: true
+        });
+
+        functionnalValidatorAllowEmpty.validate('', function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        var functionnalValidator = validator.make({
+            name: 'emptyQs',
+            required: false,
+            type: 'string'
+        });
+
+        functionnalValidator.validate('', function (error) {
+            t.ok(error, 'error.');
+        });
+    });
+
     t.test('$ref default resolves to root schema', function (t) {
         t.plan(1);
 

--- a/test/test-validation.js
+++ b/test/test-validation.js
@@ -52,7 +52,7 @@ test('validation', function (t) {
     });
 
     t.test(' empty query param pass with allowEmptyValue: true', function (t) {
-        t.plan(2);
+        t.plan(3);
 
         var functionnalValidatorAllowEmpty = validator.make({
             name: 'emptyQs',
@@ -62,6 +62,18 @@ test('validation', function (t) {
         });
 
         functionnalValidatorAllowEmpty.validate('', function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+
+        var functionnalValidatorMi = validator.make({
+            name: 'emptyQs',
+            required: false,
+            type: 'string',
+            minLength: 0
+        });
+
+        functionnalValidatorMi.validate('', function (error) {
             t.ok(!error, 'no error.');
         });
 


### PR DESCRIPTION
This PR aims to support the properties allowEmptyValue in query string (and formData).

Extract from [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) (fka Swagger RESTful API Documentation Specification):

| Field Name | Type | Description |
| --- | :-: | --- |
| <a name="parameterAllowEmptyValue"/>allowEmptyValue | `boolean` | Sets the ability to pass empty-valued parameters. This is valid only for either `query` or `formData` parameters and allows you to send a parameter with a name only or  an empty value. Default value is `false`. |

I will later create a PR on the official repository.
