### PR TITLE
swagger-schema-official version is fixed to work with npm@5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "iojs"
-  - "iojs-v1.1.0"
+  - "6"
+  - "8"
 branches:
   only:
     - master
-    - v1.0.0
+    - worldlineMaster
 before_install:
   - git submodule update --init --recursive
 script:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "core-util-is": "^1.0.1",
     "debuglog": "^1.0.1",
     "enjoi": "https://github.com/worldline/enjoi/archive/worldlineMaster.tar.gz",
-    "swagger-schema-official": "^2.0.0-"
+    "swagger-schema-official": "2.0.0-bab6bed"
   },
   "devDependencies": {
     "tape": "^2.4.2",


### PR DESCRIPTION
npm@5 no longer supports `^2.0.0-` versions : no package is installed.

A solution could be to use `^2.0.0-0`, but it's an alphanumeric comparison, so it will install `2.0.0-d79c205` instead of `2.0.0-bab6bed`.
FIY:
```js
   { modified: '2015-10-06T19:27:42.261Z',
     created: '2014-09-30T17:36:47.531Z',
     '1.2.0': '2014-09-30T17:36:47.531Z',
     '2.0.0-b6411e9': '2014-09-30T17:39:19.570Z',
     '2.0.0-a33091a': '2014-10-14T02:49:10.131Z',
     '2.0.0-0ac571a': '2015-04-20T16:47:40.613Z',
     '2.0.0-96305d9': '2015-04-21T15:36:47.563Z',
     '2.0.0-d79c205': '2015-10-02T19:29:28.437Z',
     '2.0.0-bab6bed': '2015-10-06T19:27:42.261Z' }

```